### PR TITLE
Solves pubmed.py missing dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ in progress...
 3. make a copy of config.json.bak to config.json, and populate
 4. Download RobotReviewer, and follow installation instructions (https://github.com/ijmarshall/robotreviewer)
 5. Run RobotReviewer in the REST API mode
-6. Run the following code to classify PubMed (typically 20 hours with GPU)
+6. Run the following code to classify PubMed (typically 20 hours with GPU). 
+   This requires a proper setting of `ictrp_retrieval_path`, `pubmed_local_data_path` and `pubmed_user_email` configuration variables.
 ```
 from trialstreamer import pubmed
 pubmed.download_ftp_baseline()
 ```
+
 7. run `python -m trialstreamer` to start the server on localhost:5000
 
  

--- a/trialstreamer/readers/pmreader.py
+++ b/trialstreamer/readers/pmreader.py
@@ -1,0 +1,183 @@
+#
+#   Pubmed reader
+#
+from glob import glob
+import codecs
+import re
+from trialstreamer.readers.xmlbase import XMLReader
+import xml.etree.cElementTree as ET
+
+
+def list_bounds(input_list, index, boundary):
+    """
+    returns indexed word with words surrounding
+    useful function in many places
+    for displaying collocations
+    """
+    index_lower = index - boundary
+    if index_lower < 0:
+        index_lower = 0
+
+    index_upper = index + boundary + 1
+    if index_upper > len(input_list):
+        index_upper = len(input_list)
+
+    return input_list[index_lower:index_upper]
+
+
+class NLMCorpusReader(XMLReader):
+    pass
+
+
+class PMCCorpusReader(NLMCorpusReader):
+    #
+    # not fully functioning yet - nxml files are not really valid xml - they contain HTML within some fields
+    #
+    def __init__(self, filename=None, xml_string=None, xml_ET=None):
+        NLMCorpusReader.__init__(self, filename=filename, xml_string=xml_string, xml_ET=xml_ET)
+        self.section_map["title"] = 'front/article-meta/title-group/article-title'
+        self.section_map["abstract"] = 'front/article-meta/abstract'
+
+    def title(self):
+        title = self.data.find(self.section_map["title"])
+        return self._ET2unicode(title).strip()
+
+    def abstract(self):
+        abstract = self.data.find(self.section_map["abstract"])
+        return self._ET2unicode(abstract)
+
+
+class PubmedCorpusReader(NLMCorpusReader):
+
+    def __init__(self, filename=None, xml_string=None, xml_ET=None):
+        NLMCorpusReader.__init__(self, filename=filename, xml_string=xml_string, xml_ET=xml_ET)
+        self.section_map["title"] = 'Article/ArticleTitle'
+        self.section_map["vernacular_title"] = 'Article/VernacularTitle'
+        self.section_map["abstract"] = 'Article/Abstract'
+        self.section_map["linked_ids"] = 'OtherID'
+        self.section_map["pmid"] = 'PMID'
+        self.section_map["mesh"] = 'MeshHeadingList/MeshHeading/DescriptorName'
+        self.section_map["language"] = 'Article/Language'
+        self.section_map["journal"] = 'Article/Journal/Title'
+        self.section_map["journal_abbrv"] = 'Article/Journal/ISOAbbreviation'
+        self.section_map["issue"] = 'Article/Journal/JournalIssue/Issue'
+        self.section_map["volume"] = 'Article/Journal/JournalIssue/Volume'
+        self.section_map["ptyp"] = 'Article/PublicationTypeList/PublicationType'
+        self.section_map["year"] = 'Article/Journal/JournalIssue/PubDate/Year'
+        self.section_map["medlinedate"] = 'Article/Journal/JournalIssue/PubDate/MedlineDate'
+        self.section_map["month"] = 'Article/Journal/JournalIssue/PubDate/Month'
+        self.section_map["pages"] = 'Article/Pagination/MedlinePgn'
+        self.section_map["registry_ids"] = 'Article/DataBankList/DataBank/AccessionNumberList/AccessionNumber'
+        self.section_map["chemical_list"] = 'ChemicalList/Chemical/NameOfSubstance'
+
+    def title(self):
+        title = self.data.find(self.section_map["title"])
+        title_try1 = self._ET2unicode(title).strip()
+        if title_try1 != '' and title_try1 != '[Not Available].':
+            return title_try1
+        else:
+            title = self.data.find(self.section_map["vernacular_title"])
+            title_try2 = self._ET2unicode(title).strip()
+            if title_try2 != '' and title_try2 != '[Not Available].':
+                return title_try2
+            else:
+                return ''
+
+    def abstract(self):
+        abstract_sections = self.data.findall('Article/Abstract/AbstractText')
+        abstract_text = []
+        for sec in abstract_sections:
+            header = sec.get('Label', "_UNSTRUCTURED")
+            abstract_text.append({"header": header,
+                                  "text": self._ET2unicode(sec).strip()})
+
+        return abstract_text
+
+    def abstract_plaintext(self):
+        out = []
+        for sec in self.abstract():
+            if sec["header"] != "_UNSTRUCTURED":
+                out.append(sec["header"])
+                out.append("\n")
+            out.append(sec["text"])
+
+        return "\n".join(out)
+
+    def authors(self):
+        output = []
+        author_list = self.data.findall('Article/AuthorList/Author')
+        for author_el in author_list:
+            output.append({"Initials": self._ET2unicode(author_el.find('Initials')).strip(),
+                      "LastName": self._ET2unicode(author_el.find('LastName')).strip(),
+                        "ForeName":self._ET2unicode(author_el.find('ForeName')).strip(),
+                        "Affiliation":self._ET2unicode(author_el.find('AffiliationInfo/Affiliation')).strip()})
+        return output
+
+    def doi(self):
+        eids = self.data.findall('Article/ELocationID')
+        return [e.text for e in eids if e.attrib.get('EIdType')=='doi']
+
+    def is_pmc_linked(self):
+        els = self.data.findall('OtherID')
+        if len(els) > 0:
+            for el in els:
+                text = self._ET2unicode(el)
+                result = re.match("PMC[0-9]+", text)
+                if result is not None:
+                    return result.group(0)
+        return None
+
+    def parse_pages(self, page_string):
+        parts = page_string.split('-')
+        if len(parts) == 2:
+            l0, l1 = len(parts[0]), len(parts[1])
+            page_to = parts[0][:l0-l1] + parts[1]
+            page_from = parts[0]
+            return {"page_from":page_from, "page_to":page_to}
+        elif len(parts)==1:
+            page_from, page_to = parts[0], parts[0]
+            return {"page_from":page_from, "page_to":page_to}
+        else:
+            return {}
+
+    def yr_proc(self, raw_date):
+        m = re.search(r"\b(19|20)\d{2}\b", raw_date)
+        if m:
+            return m.group(0)
+        else:
+            return None
+
+    def year(self):
+        yr_try1 = self.text_filtered('year')
+        if yr_try1 != '':
+            return yr_try1
+        else:
+            yr_try2 = self.yr_proc(self.text_filtered('medlinedate'))
+            return yr_try2
+
+    def to_dict(self):
+        out = {"pmid": self.text_filtered('pmid'),
+               "status": self.status(),
+               "indexing_method": self.indexing_method(),
+               "title": self.title(),
+               "abstract": self.abstract(),
+               "abstract_plaintext": self.abstract_plaintext(),
+               "authors": self.authors(),
+               "journal": self.text_filtered('journal'),
+               "journal_abbrv": self.text_filtered('journal_abbrv'),
+               "year": self.year(),
+               "mesh": self.text_filtered_all('mesh'),
+               "month": self.text_filtered('month'),
+               "volume": self.text_filtered('volume'),
+               "issue": self.text_filtered('issue'),
+               "pages": self.parse_pages(self.text_filtered('pages')),
+               "ptyp": self.text_filtered_all('ptyp'),
+               "registry_ids": self.text_filtered_all('registry_ids'),
+               "dois": self.doi()}
+        return out
+
+    def status(self):
+        return self.data.attrib.get('Status')
+
+    def indexing_method(self):
+        return self.data.attrib.get('IndexingMethod', 'Human')

--- a/trialstreamer/readers/xmlbase.py
+++ b/trialstreamer/readers/xmlbase.py
@@ -1,0 +1,95 @@
+#
+# XML reader base class
+#
+
+try:
+    import xml.etree.cElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
+
+# from lxml import etree as ET
+
+class XMLReader():
+    """
+    new faster version which doesn't use NLTK
+    returns plain text - tokenization should be done externally
+    """
+
+    def __init__(self, filename=None, xml_string=None, xml_ET=None):
+
+        self.filename=filename
+
+        if filename:            
+            self.parse_file(filename)
+        elif xml_string:
+            self.parse_string(xml_string)
+        elif xml_ET:
+            self.data = xml_ET
+        else:
+            raise TypeError('Missing XML data in any of filename, xml_string, or xml_ET')
+
+
+        self.section_map = {}
+
+    # def __getattr__(self, attr):
+    #     result = self.text_filtered_all(attr)
+    #     return result
+
+
+    def __dir__(self):
+        return self.section_map.keys()
+
+    def parse_file(self, filename):
+        self.data = ET.parse(filename)
+
+    def parse_string(self, xml_string):
+        self.data =  ET.fromstring(xml_string)
+
+    def _ET2unicode(self, ET_instance, strip_tags=True):
+        "returns unicode of elementtree contents"
+        if ET_instance is not None:
+            if strip_tags:
+                # print "tags stripped!"
+                return ' '.join([s for s in ET.tostringlist(
+                                        ET_instance, method="text", encoding="unicode") if s is not None])
+
+            else:
+                return ET.tostring(ET_instance, method="xml", encoding="utf-8").decode("utf-8")
+        else:
+            return u""
+
+
+
+    def _ETfind(self, element_name, ET_instance, strip_tags=True):
+        "finds (first) subelement, returns unicode of contents if present, else returns None"
+        subelement = ET_instance.find(element_name)
+        if subelement is not None:
+            return self._ET2unicode(subelement, strip_tags=strip_tags)
+        else:
+            return ""
+
+    def text_filtered(self, part_id=None):
+        if type(part_id) is str:
+            return self._ET2unicode(self.xml_filtered(part_id=part_id)).strip()
+        elif type(part_id) is list:
+            return {p: self._ET2unicode(self.xml_filtered(part_id=p).strip()) for p in part_id}
+
+    def text_filtered_all(self, part_id=None):
+        if type(part_id) is str:
+            return [self._ET2unicode(part).strip() for part in self.xml_filtered_all(part_id=part_id)]
+        elif type(part_id) is list:
+            return {p: [self._ET2unicode(part).strip() for part in self.xml_filtered_all(part_id=p)] for p in part_id}
+
+    def text_all(self):
+        output = {}
+        for part_id, loc in self.section_map.iteritems():
+            output[part_id] = self._ET2unicode(self.data.find(loc))
+        return output
+
+    def xml_filtered_all(self, part_id=None):
+        return self.data.findall(self.section_map[part_id])
+
+    def xml_filtered(self, part_id=None):
+        return self.data.find(self.section_map[part_id])
+
+    get = text_filtered_all # synonym

--- a/trialstreamer_env.yml
+++ b/trialstreamer_env.yml
@@ -57,5 +57,7 @@ dependencies:
     - swagger-ui-bundle==0.0.6
     - urllib3==1.25.8
     - zipp==2.0.0
+    - python-dateutil==2.8.2
+    - tqdm==4.62.2
 prefix: /home/iain/anaconda3/envs/trialstreamer
 


### PR DESCRIPTION
### Problem

When trying to run the `pubmed.py` script as shown in the project's `README.md`, an error was shown for the line `from robotdata.readers import pmreader`, since no `robotdata` module was found, which was found to be from the private **robotdata** repository.

The dependencies `dateutil` and `tqdm` were also missing from the `trialstreamer_env.yml` specifications.

### Solution

Imported the `readers` module from **robotdata** project at commit [f692fbe](https://github.com/ijmarshall/robotdata/commit/f692fbeb3f65dbe29389d094d03c87fa0ea5b4d3), only copying necessary files for the `pubmed.py` script.
Updated missing pip dependencies.